### PR TITLE
fix/header image

### DIFF
--- a/src/components/commons/Logo/index.jsx
+++ b/src/components/commons/Logo/index.jsx
@@ -1,14 +1,11 @@
 import React from 'react';
 
 import { LogoLink } from './styles';
-import { Box } from '@mui/material';
 
 const Logo = () => {
   return (
     <LogoLink to="/dashboard">
-      <Box sx={{ height: '100%' }}>
-        <img src='projectmap-logo-for-header.png' height='100%' />
-      </Box>
+      <img src='/projectmap-logo-for-header.png' height='100%' />
       <span>ProjectMap</span>
     </LogoLink>
   );

--- a/src/components/commons/Logo/styles.js
+++ b/src/components/commons/Logo/styles.js
@@ -6,7 +6,6 @@ import { COLORS } from 'helpers/enums/colors';
 export const LogoLink = styled(Link)({
   color: COLORS.white,
   display: 'flex',
-  fontSize: 24,
   textDecoration: 'none',
   height: '100%',
   alignItems: 'center',


### PR DESCRIPTION
Trello: N/A
Cambios:
* Se usa la ruta absoluta para la imagen en lugar de la relativa, para que pueda accederse siempre sin importar la URL en la que está actualmente
* Se saca un Box innecesario que parece que era lo que causaba problemas en Firefox