### PR TITLE
Fix/change prop name in GET /projects/:id

### DIFF
--- a/src/containers/ProjectContainer.jsx
+++ b/src/containers/ProjectContainer.jsx
@@ -264,7 +264,7 @@ const ProjectContainer = () => {
     const users = members.map((m) => ({
       userId: m.user._id,
       role: m.role,
-      spheres: m.role === 'participant' ? m.spheres : undefined,
+      stages: m.role === 'participant' ? m.stages : undefined,
     }));
     dispatch(onSaveMembers(id, { users }))
   }
@@ -274,7 +274,7 @@ const ProjectContainer = () => {
     projectInfo?.coordinators.find((u) => u.email === user?.email)
 
   const stepPermissions = projectInfo?.participants
-    .find((u) => u.user.email === user?.email)?.spheres
+    .find((u) => u.user.email === user?.email)?.stages
 
   return (
     <LayoutContainer>

--- a/src/helpers/permissions.js
+++ b/src/helpers/permissions.js
@@ -8,7 +8,7 @@ export default function permission(rootState, stepId) {
   if (hasFullPermissions) return 'edit';
 
   const stepPermissions = projectInfo?.participants
-    .find((u) => u.user.email === user?.email)?.spheres;
+    .find((u) => u.user.email === user?.email)?.stages;
   if (!stepPermissions) return 'hide';
   return stepPermissions.find((p) => p.id === stepId).permission;
 }

--- a/src/redux/reducers/projects.reducer.js
+++ b/src/redux/reducers/projects.reducer.js
@@ -301,8 +301,8 @@ const projectsReducer = (state = defaultState, action) => {
     case constants.PROJECTS_CHANGE_MEMBER_ROLE:
       let newMember = state.members.find((m) => m.user._id === data.userId);
       newMember.role = data.newRole;
-      if (!newMember.spheres) {
-        newMember.spheres = Object.keys(stepNames).map((s) => ({ id: s, permission: 'hide' }))
+      if (!newMember.stages) {
+        newMember.stages = Object.keys(stepNames).map((s) => ({ id: s, permission: 'hide' }))
       }
       return {
         ...state,
@@ -316,7 +316,7 @@ const projectsReducer = (state = defaultState, action) => {
         // replace one sphere's permission in one member according to change
         members: state.members.map((m) =>
           m.user._id !== data.userId ? m : {
-            ...m, spheres: m.spheres.map((s) =>
+            ...m, stages: m.stages.map((s) =>
               s.id !== data.stepId ? s : { id: s.id, permission: data.newPermission }
             )
           }

--- a/src/views/ProjectView/tabs/rolesTab.jsx
+++ b/src/views/ProjectView/tabs/rolesTab.jsx
@@ -111,7 +111,7 @@ export default function RolesTab({
                 {memberRoleCell(member.user._id, member.role, onChangeMemberRole)}
                 {Object.keys(stepNames).map((step) =>
                   member.role === 'participant' ? (
-                    memberStepPermissionCell(member.user._id, step, member.spheres.find((s) => s.id === step)?.permission, onChangeMemberPermission)
+                    memberStepPermissionCell(member.user._id, step, member.stages.find((s) => s.id === step)?.permission, onChangeMemberPermission)
                   ) : <TableCell>-</TableCell>
                 )}
               </TableRow>


### PR DESCRIPTION
Trello: N/A
Cambios: se pasa a usar "stages" en lugar de "spheres" al procesar la respuesta de este endpoint acorde al cambio de contrato.