### PR TITLE
Fix/filter OKR frequencies

### DIFF
--- a/src/helpers/enums/okr.js
+++ b/src/helpers/enums/okr.js
@@ -65,7 +65,7 @@ export const priorityOptions = [
 
 // A 15 dias: diario, semanal
 // A 1 mes: semanal, quincenal
-// A 2 meses: 
+// A 2 meses: semanal, quincenal, mensual
 // A 3 meses: quincenal, mensual
 // A 6 meses: mensual, bimestral, trimestral
 // A 1 año: mensual, bimestral, trimestral

--- a/src/helpers/enums/okr.js
+++ b/src/helpers/enums/okr.js
@@ -65,6 +65,7 @@ export const priorityOptions = [
 
 // A 15 dias: diario, semanal
 // A 1 mes: semanal, quincenal
+// A 2 meses: 
 // A 3 meses: quincenal, mensual
 // A 6 meses: mensual, bimestral, trimestral
 // A 1 año: mensual, bimestral, trimestral
@@ -74,6 +75,9 @@ export function filterFrequenciesByHorizon(horizon) {
   }
   if (horizon === 30) {
     return ['Semanal', 'Quincenal']
+  }
+  if (horizon === 60) {
+    return ['Semanal', 'Quincenal', 'Mensual']
   }
   if (horizon === 90) {
     return ['Quincenal', 'Mensual']

--- a/src/helpers/enums/okr.js
+++ b/src/helpers/enums/okr.js
@@ -62,3 +62,24 @@ export const priorityOptions = [
   '/priorities/medium.svg',
   '/priorities/high.svg'
 ]
+
+// A 15 dias: diario, semanal
+// A 1 mes: semanal, quincenal
+// A 3 meses: quincenal, mensual
+// A 6 meses: mensual, bimestral, trimestral
+// A 1 año: mensual, bimestral, trimestral
+export function filterFrequenciesByHorizon(horizon) {
+  if (horizon === 15) {
+    return ['Diario', 'Semanal']
+  }
+  if (horizon === 30) {
+    return ['Semanal', 'Quincenal']
+  }
+  if (horizon === 90) {
+    return ['Quincenal', 'Mensual']
+  }
+  if (horizon === 180 || horizon === 360) {
+    return ['Mensual', 'Bimestral', 'Trimestral']
+  }
+  return []
+}

--- a/src/views/OKRView/indexv2.jsx
+++ b/src/views/OKRView/indexv2.jsx
@@ -1,4 +1,4 @@
-import { frequencyOptions, horizonOptions, priorityOptions } from "helpers/enums/okr";
+import { filterFrequenciesByHorizon, horizonOptions, priorityOptions } from "helpers/enums/okr";
 import { EditObjectiveButton, KeyResultsContainer, OkrContainerV2, OkrHeader, OkrMoreData, OkrTitle } from "./styles";
 import Button from "components/commons/Button";
 import Modal from "components/commons/Modal";
@@ -129,7 +129,7 @@ const OKRView = ({
                   name="frequency"
                   placeholder="Frecuencia"
                   component={SelectInput}
-                  options={Object.values(frequencyOptions)}
+                  options={filterFrequenciesByHorizon(okrData?.horizon)}
                   validate={validateField}
                 />
                 <ErrorMessage name="frequency">


### PR DESCRIPTION
Trello: https://trello.com/c/6MelzxpP/103-limitar-dropdown-de-las-frecuencias-segun-el-horizonte-del-okr-f
Cambios: se agrega el filtro de frecuencias, similar al empleado en BSCs.