### PR TITLE
Fix/redirect to new Ansoff when creating it

### DIFF
--- a/src/redux/selectors/app.selector.js
+++ b/src/redux/selectors/app.selector.js
@@ -12,5 +12,5 @@ const getQuestionnaireLoading = (state) => state.questionnaire.loading;
 export const toolsLoadingSelector = createSelector(
   [getFodaLoading, getPestelLoading, getPorterLoading, getAnsoffLoading, getMcKinseyLoading, getOkrLoading, getBSLoading, getQuestionnaireLoading],
   (fodaLoading, pestelLoading, porterLoading, ansoffLoading, mcKinseyLoading, okrLoading, bsLoading, questionnaireLoading) =>
-    fodaLoading || pestelLoading || porterLoading || mcKinseyLoading || okrLoading || bsLoading || questionnaireLoading
+    fodaLoading || pestelLoading || porterLoading || ansoffLoading || mcKinseyLoading || okrLoading || bsLoading || questionnaireLoading
 );


### PR DESCRIPTION
Trello: https://trello.com/c/1s8Xgufy/180-al-crear-una-matriz-ansoff-no-se-redirige-autom%C3%A1ticamente-a-la-herramienta-f
Cambios: se completa el `toolsLoadingSelector` para respetar el tiempo de carga de la creación del Ansoff.