### PR TITLE
Feature/create OKR with parent

### DIFF
--- a/src/containers/ProjectContainer.jsx
+++ b/src/containers/ProjectContainer.jsx
@@ -582,7 +582,9 @@ function ParentInput(props) {
     const parentEdge = organizationalChart.edges.find((e) => e.target === node.id)
     if (!parentEdge) return []
     const parentNode = organizationalChart.nodes.find((n) => n.id === parentEdge.source)
-    return allOkrs.filter((okr) => okr.area === parentNode.data.label).map((okr) => okr.description)
+    return allOkrs
+      .filter((okr) => okr.area === parentNode.data.label && okr.keyResults.length === 0)
+      .map((okr) => okr.description)
   }, [values.area])
 
   return (

--- a/src/containers/ProjectContainer.jsx
+++ b/src/containers/ProjectContainer.jsx
@@ -443,7 +443,7 @@ const ProjectContainer = () => {
       >
         <Formik
           onSubmit={(values) => onSubmitTool(addTool.action, values)}
-          initialValues={{ titulo: '', area: NO_AREA }}
+          initialValues={{ titulo: '', area: NO_AREA, parent: NO_PARENT }}
         >
           {({ handleSubmit }) => (
             <Form onSubmit={handleSubmit}>

--- a/src/containers/ProjectContainer.jsx
+++ b/src/containers/ProjectContainer.jsx
@@ -3,7 +3,7 @@ import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate, useParams } from 'react-router-dom';
 import { ButtonBase, IconButton, Menu, MenuItem, Popover } from '@mui/material';
-import { Formik, Field, ErrorMessage, Form } from 'formik';
+import { Formik, Field, ErrorMessage, Form, useFormikContext } from 'formik';
 import { Box } from '@mui/system';
 import { Typography } from '@mui/material';
 import { PopupModal } from 'react-calendly';
@@ -76,6 +76,7 @@ import DateInput from 'components/inputs/DateInput';
 import { onGetOrganizationalChart } from 'redux/actions/projects.actions';
 
 const NO_AREA = 'Sin área'
+const NO_PARENT = 'Sin padre'
 
 const ProjectContainer = () => {
   let { id } = useParams();
@@ -97,7 +98,6 @@ const ProjectContainer = () => {
 
   const [rolesTabChanged, setRolesTabChanged] = useState(false);
 
-  // const menuItems = getMenuItems(stepValue);
   const toolsItems = useSelector(stepToolsSelector);
   const toolsAddOptions = getMenuItems(stepValue);
   const stepsColors = useSelector(progressSelector);
@@ -116,6 +116,7 @@ const ProjectContainer = () => {
   const user = useSelector((state) => state.user.data);
   const loading = useSelector(getLoadingSelector);
   const { organizationalChart } = useSelector((state) => state.projects);
+  const allOkrs = useSelector((state) => state.projects.okrs);
 
   const onClickButtonGoBack = () => {
     if (user?.role && user?.role === 'AdminConsultant')
@@ -478,6 +479,15 @@ const ProjectContainer = () => {
                   validate={validateField}
                 />
               }
+              {addTool?.parent &&
+                <Field
+                  name="parent"
+                  fieldLabel="OKR padre"
+                  component={ParentInput}
+                  allOkrs={allOkrs}
+                  validate={validateField}
+                />
+              }
               <ButtonsContainer>
                 <Button color="secondary" onClick={() => setAddTool(null)}>
                   Cancelar
@@ -549,3 +559,17 @@ const ProjectContainer = () => {
 };
 
 export default ProjectContainer;
+
+function ParentInput(props) {
+  const { allOkrs } = props
+  const { values } = useFormikContext()
+  const canHaveParent = values.area !== NO_AREA
+  const possibleParents = allOkrs.filter((okr) => okr.area === values.area).map((okr) => okr.description)
+  const options = [NO_PARENT].concat(canHaveParent ? possibleParents : [])
+  return (
+    <SelectInputV2
+      options={options}
+      {...props}
+    />
+  )
+}

--- a/src/helpers/enums/steps.js
+++ b/src/helpers/enums/steps.js
@@ -36,7 +36,14 @@ export const STEPS = [
     title: 'Planeamiento Financiero y Medición de Resultados',
     menuItems: [
       { titulo: 'Agregar Balanced Scorecard', action: onCreateBalanced, horizon: bscHorizonOptions },
-      { titulo: 'Agregar OKR', action: onCreateOkr, area: true, horizon: okrHorizonOptions, requireStartDate: true },
+      {
+        titulo: 'Agregar OKR',
+        action: onCreateOkr,
+        area: true,
+        horizon: okrHorizonOptions,
+        requireStartDate: true,
+        parent: true,
+      },
     ],
     id: 'financialPlanning',
     color: '#fcb6d4'

--- a/src/redux/sagas/okr.sagas.js
+++ b/src/redux/sagas/okr.sagas.js
@@ -7,6 +7,7 @@ import {
   deleteOkr,
   deleteKeyResult,
   editOneOkr,
+  assignParent,
 } from 'services/okr.services';
 
 import * as constants from 'redux/contansts/okr.constants';
@@ -24,6 +25,12 @@ export function* okrCreateTool(action) {
       startingDate: formData.startingDate,
     };
     const { data } = yield call(createOkr, req);
+    
+    const { parentId } = formData;
+    if (parentId) {
+      yield call(assignParent, data._id, { parentOkrId: parentId });
+    };
+
     yield put({ type: constants.CREATE_OKR_TOOL_SUCCEEDED, data });
   } catch (error) {
     yield put({

--- a/src/redux/selectors/project.selector.js
+++ b/src/redux/selectors/project.selector.js
@@ -1,5 +1,4 @@
 import { CompletitionColors } from 'helpers/enums/completition';
-import { getMenuItems } from 'helpers/enums/steps';
 import { createSelector } from 'reselect';
 
 const getFodas = (state) =>

--- a/src/services/okr.services.js
+++ b/src/services/okr.services.js
@@ -16,3 +16,6 @@ export const editKeyResult = (id, keyResultId, formData) =>
 
 export const deleteKeyResult = (id, keyResultId) =>
   remove(`okr/${id}/key-result/${keyResultId}`);
+
+export const assignParent = (id, formData) =>
+  post(`okr/${id}/parent`, formData);


### PR DESCRIPTION
Trello: https://trello.com/c/vThSKRgs/137-adaptar-creaci%C3%B3n-de-okr-para-padres-hijos-f
Depende de: https://github.com/jschuhmann47/projectMap-Backend/pull/35
Cambios:
- Se agrega selector de padre, con opción "Sin padre" y más opciones acordes a los OKRs del área padre de la seleccionada.
- Se agrega llamada a endpoint para asignar padre luego de crear el OKR.