### PR TITLE
Fix/PESTEL & McKinsey results overlap

### DIFF
--- a/src/containers/MCKINSEY/McKinseyContainerResults.jsx
+++ b/src/containers/MCKINSEY/McKinseyContainerResults.jsx
@@ -18,7 +18,7 @@ import { Box, Grid } from '@mui/material';
 import { Menu, MenuItem } from '@mui/material';
 import Comments from 'components/comments/Comments';
 import { COLORS } from 'helpers/enums/colors';
-import { Container } from 'views/FodaView/styles';
+import { Container } from 'views/PestelView/styles';
 import RadarChartCustom from 'components/commons/RadarChart';
 
 const McKinseyContainerResults = () => {
@@ -69,8 +69,8 @@ const McKinseyContainerResults = () => {
   return (
     <LayoutContainer>
       <Container>
-        <Grid container sx={{ height: '100%' }}>
-          <Grid item sx={{ height: '100%' }}>
+        <Box sx={{ width: '90%' }}>
+          <Box sx={{ height: 'max-content' }}>
             <McKinseyView
               cuadrantes={cuadrantes}
               showResults
@@ -78,7 +78,7 @@ const McKinseyContainerResults = () => {
               title={title}
               onClickGoBackButton={onClickGoBackButton}
             />
-          </Grid>
+          </Box>
           <Menu
             anchorEl={anchorElement}
             onClose={() => setAnchorElement(null)}
@@ -98,10 +98,14 @@ const McKinseyContainerResults = () => {
               <Comments show tool="MCKINSEY" toolId={matrizId} projectId={id} />
             </MenuItem>
           </Menu>
-          <Grid item sx={{ height: '100%', marginTop: '40px' }}>
-            <Grid container>
-              <Grid item sx={{ padding: '30px' }}>
-                <Title>Tabla de Resultados</Title>
+            <Box sx={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              width: '100%'
+            }}>
+              <Title>Tabla de Resultados</Title>
+              <Box sx={{ paddingLeft: '30px', paddingRight: '30px' }}>
                 <CustomizedTables
                   items={cuadrantesOrdenados}
                   columns={[
@@ -119,16 +123,13 @@ const McKinseyContainerResults = () => {
                     },
                   ]}
                 />
-              </Grid>
-            </Grid>
-          </Grid>
-          <Box sx={{ margin: '0 auto', marginTop: '10%' }}>
-            <SectionRadar sx={{ textAlign: 'center' }}>
-              <Title>Gráfico de Radar</Title>
-              <RadarChartCustom data={buildChartData()} />
-            </SectionRadar>
-          </Box>
-        </Grid>
+              </Box>
+            </Box>
+          <SectionRadar>
+            <Title>Gráfico de Radar</Title>
+            <RadarChartCustom data={buildChartData()} />
+          </SectionRadar>
+        </Box>
       </Container>
     </LayoutContainer>
   );

--- a/src/containers/PESTEL/PestelContainer.jsx
+++ b/src/containers/PESTEL/PestelContainer.jsx
@@ -7,6 +7,7 @@ import Button from 'components/commons/Button';
 import { COLORS } from 'helpers/enums/colors';
 import {
   Container,
+  ViewContainer,
 } from 'views/PestelView/styles';
 import PestelView from 'views/PestelView';
 import {
@@ -101,97 +102,99 @@ const PestelContainer = () => {
   return (
     <LayoutContainer>
       <Container>
-        <PestelView
-          onAdd={onAdd}
-          politicos={politicos}
-          economicos={economicos}
-          sociales={sociales}
-          tecnologicos={tecnologicos}
-          ambientales={ambientales}
-          legales={legales}
-          onEdit={onEdit}
-          onDelete={onDelete}
-          title={title}
-          onClickButton={onClickResultsButton}
-          onClickButtonGoBack={onClickResultsButtonGoBack}
-          buttonTitle="Resultados"
-          openComments={(target) => setAnchorElement(target)}
-          userPermission={userPermission}
-        />
-        <Menu
-          anchorEl={anchorElement}
-          onClose={() => setAnchorElement(null)}
-          open={!!anchorElement}
-          PaperProps={{
-            style: {
-              width: 500,
-            },
-          }}
-          sx={{
-            '& .MuiMenu-list': {
-              background: COLORS.AthensGray,
-            },
-          }}
-        >
-          <MenuItem key={1} disableRipple>
-            <Comments show tool="PESTEL" toolId={pestelId} projectId={id} />
-          </MenuItem>
-        </Menu>
-        <ModalV2
-          isOpen={!!factor}
-          title={
-            !!factor?.area
-            ? `Editar factor ${factor?.area}`
-            : `Agregar factor ${factor}`
-          }
-          onClose={() => setFactor('')}
-        >
-          <Formik onSubmit={onSubmitFactor} initialValues={initialValues}>
-            {({ handleSubmit }) => (
-              <Form onSubmit={handleSubmit}>
-                <Field
-                  name="descripcion"
-                  fieldLabel="Descripción"
-                  component={InputV2}
-                  validate={validateField}
-                  tooltip="Seleccione o escriba el factor que quiere agregar a su análisis."
-                />
-                <Field
-                  name="importancia"
-                  component={SelectInputV2}
-                  options={importancia}
-                  fieldLabel="Importancia"
-                  validate={validateField}
-                  tooltip="Algunos factores que agregue en su análisis tendrán mayor impacto que otros. Si algo tiene un gran impacto, positivo o negativo, en su organización, utilice la opción superior, de ser menos importante, la inferior"
-                />
-                <Field
-                  name='intensidad'
-                  component={SelectInputV2}
-                  options={intensidad}
-                  fieldLabel='Intensidad'
-                  validate={validateField}
-                  tooltip="Los factores a agregar se pueden manifestar con fuerza variable. No es lo mismo por ejemplo, una inflación del 2% a una de 20%. Utilice esta escala para describir ese comportamiento."
-                />
-                <Field
-                  name="tendencia"
-                  component={SelectInputV2}
-                  options={tendencia}
-                  fieldLabel='Tendencia'
-                  validate={validateField}
-                  tooltip="Un factor necesariamente tiene una tendencia, ¿Está empeorando o mejorando?, ¿Está tendiendo a desaparecer o se está volviendo más importante?. Utilice estas 5 posibilidades para representar este comportamiento."
-                />
-                <ButtonsContainer>
-                  <Button color="secondary" onClick={() => setFactor('')}>
-                    Cancelar
-                  </Button>
-                  <Button type="submit">
-                    {!!factor?.area ? 'Editar' : 'Agregar'}
-                  </Button>
-                </ButtonsContainer>
-              </Form>
-            )}
-          </Formik>
-        </ModalV2>
+        <ViewContainer>
+          <PestelView
+            onAdd={onAdd}
+            politicos={politicos}
+            economicos={economicos}
+            sociales={sociales}
+            tecnologicos={tecnologicos}
+            ambientales={ambientales}
+            legales={legales}
+            onEdit={onEdit}
+            onDelete={onDelete}
+            title={title}
+            onClickButton={onClickResultsButton}
+            onClickButtonGoBack={onClickResultsButtonGoBack}
+            buttonTitle="Resultados"
+            openComments={(target) => setAnchorElement(target)}
+            userPermission={userPermission}
+          />
+          <Menu
+            anchorEl={anchorElement}
+            onClose={() => setAnchorElement(null)}
+            open={!!anchorElement}
+            PaperProps={{
+              style: {
+                width: 500,
+              },
+            }}
+            sx={{
+              '& .MuiMenu-list': {
+                background: COLORS.AthensGray,
+              },
+            }}
+          >
+            <MenuItem key={1} disableRipple>
+              <Comments show tool="PESTEL" toolId={pestelId} projectId={id} />
+            </MenuItem>
+          </Menu>
+          <ModalV2
+            isOpen={!!factor}
+            title={
+              !!factor?.area
+              ? `Editar factor ${factor?.area}`
+              : `Agregar factor ${factor}`
+            }
+            onClose={() => setFactor('')}
+          >
+            <Formik onSubmit={onSubmitFactor} initialValues={initialValues}>
+              {({ handleSubmit }) => (
+                <Form onSubmit={handleSubmit}>
+                  <Field
+                    name="descripcion"
+                    fieldLabel="Descripción"
+                    component={InputV2}
+                    validate={validateField}
+                    tooltip="Seleccione o escriba el factor que quiere agregar a su análisis."
+                  />
+                  <Field
+                    name="importancia"
+                    component={SelectInputV2}
+                    options={importancia}
+                    fieldLabel="Importancia"
+                    validate={validateField}
+                    tooltip="Algunos factores que agregue en su análisis tendrán mayor impacto que otros. Si algo tiene un gran impacto, positivo o negativo, en su organización, utilice la opción superior, de ser menos importante, la inferior"
+                  />
+                  <Field
+                    name='intensidad'
+                    component={SelectInputV2}
+                    options={intensidad}
+                    fieldLabel='Intensidad'
+                    validate={validateField}
+                    tooltip="Los factores a agregar se pueden manifestar con fuerza variable. No es lo mismo por ejemplo, una inflación del 2% a una de 20%. Utilice esta escala para describir ese comportamiento."
+                  />
+                  <Field
+                    name="tendencia"
+                    component={SelectInputV2}
+                    options={tendencia}
+                    fieldLabel='Tendencia'
+                    validate={validateField}
+                    tooltip="Un factor necesariamente tiene una tendencia, ¿Está empeorando o mejorando?, ¿Está tendiendo a desaparecer o se está volviendo más importante?. Utilice estas 5 posibilidades para representar este comportamiento."
+                  />
+                  <ButtonsContainer>
+                    <Button color="secondary" onClick={() => setFactor('')}>
+                      Cancelar
+                    </Button>
+                    <Button type="submit">
+                      {!!factor?.area ? 'Editar' : 'Agregar'}
+                    </Button>
+                  </ButtonsContainer>
+                </Form>
+              )}
+            </Formik>
+          </ModalV2>
+        </ViewContainer>
       </Container>
       {loading && <Loading isModalMode message="Cargando PESTEL" />}
     </LayoutContainer>

--- a/src/containers/PESTEL/PestelContainerResults.jsx
+++ b/src/containers/PESTEL/PestelContainerResults.jsx
@@ -40,7 +40,7 @@ import ToolTip from 'components/commons/ToolTip';
 
 const PestelContainer = () => {
   const { pestelId, id } = useParams();
-  const disptch = useDispatch();
+  const dispatch = useDispatch();
   const politicos = useSelector(politicoSelectorOrdenadas);
   const economicos = useSelector(economicoSelectorOrdenadas);
   const sociales = useSelector(socialSelectorOrdenadas);
@@ -60,8 +60,8 @@ const PestelContainer = () => {
   const [anchorElement, setAnchorElement] = useState(null);
 
   useEffect(() => {
-    disptch(onGetOptions());
-    disptch(onGetOne(pestelId));
+    dispatch(onGetOptions());
+    dispatch(onGetOne(pestelId));
   }, []);
 
   return (

--- a/src/views/McKinseyView/index.jsx
+++ b/src/views/McKinseyView/index.jsx
@@ -61,7 +61,7 @@ const McKinseyView = ({
   //  top: 50%;
   //  rotate: 270deg;
   const renderBox = (backgroundcolor, child, showText = false) => (
-    <Grid item xs={4} sx={{ display: 'flex', height: '33%' }}>
+    <Grid item xs={4} sx={{ display: 'flex', minHeight: '33%' }}>
       {/* {showText && <span>hola</span>} */}
       <CardContent backgroundcolor={backgroundcolor}>{child}</CardContent>
     </Grid>

--- a/src/views/McKinseyView/styles.js
+++ b/src/views/McKinseyView/styles.js
@@ -152,5 +152,9 @@ export const SectionTable = styled('div')({
   padding: '30px 0',
   gap: 20,
 });
-export const SectionRadar = styled('div')({});
-export const SectionPie = styled('div')({});
+export const SectionRadar = styled('div')({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  marginTop: '20px',
+});

--- a/src/views/PestelView/styles.js
+++ b/src/views/PestelView/styles.js
@@ -6,7 +6,6 @@ import { COLORS } from 'helpers/enums/colors';
 export const Container = styled('div')({
   display: 'flex',
   flexDirection: 'column',
-  maxWidth: 1300,
   alignItems: 'center',
   width: '100%',
 });

--- a/src/views/PestelView/styles.js
+++ b/src/views/PestelView/styles.js
@@ -6,12 +6,9 @@ import { COLORS } from 'helpers/enums/colors';
 export const Container = styled('div')({
   display: 'flex',
   flexDirection: 'column',
-  margin: '0 auto',
   maxWidth: 1300,
   alignItems: 'center',
-  justifyContent: 'center',
-  height: '100%',
-  width: '90%',
+  width: '100%',
 });
 
 export const ButtonContainer = styled('div')({
@@ -119,10 +116,9 @@ export const ChipContainer = styled('div')({
 
 export const ViewContainer = styled('div')({
   display: 'flex',
-  flex: 1,
   margin: '0 auto',
   flexDirection: 'column',
-  height: '100%',
+  width: '90%',
 });
 
 export const ChartContainer = styled('div')({


### PR DESCRIPTION
Trello: N/A
Se arreglan las vistas de resultados de PESTEL y McKinsey, en las que antes los gráficos se superponían con los grids, ahora se apilan como Dios manda.